### PR TITLE
[EXAMPLE] Feature: JSON Error handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Application\\": "module/Application/src/"
+            "Application\\": "module/Application/src/",
+            "JsonErrorHandling\\": "module/JsonErrorHandling/src/JsonErrorHandling"
         }
     }
 }

--- a/config/modules.config.php
+++ b/config/modules.config.php
@@ -5,4 +5,5 @@ return [
     'Zend\Router',
     'Zend\Validator',
     'Application',
+    'JsonErrorHandling',
 ];

--- a/module/JsonErrorHandling/src/JsonErrorHandling/JsonErrorHandler.php
+++ b/module/JsonErrorHandling/src/JsonErrorHandling/JsonErrorHandler.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace JsonErrorHandling;
+
+use Zend\EventManager\AbstractListenerAggregate;
+use Zend\EventManager\EventManagerInterface;
+use Zend\Http\Header\Accept;
+use Zend\Http\Request;
+use Zend\Http\Response;
+use Zend\Mvc\Application;
+use Zend\Mvc\MvcEvent;
+use Zend\View\Model\JsonModel;
+use Zend\View\Model\ModelInterface;
+
+final class JsonErrorHandler extends AbstractListenerAggregate
+{
+    /**
+     * @var bool
+     */
+    private $displayExceptions;
+
+    public function __construct(bool $displayExceptions)
+    {
+        $this->displayExceptions = $displayExceptions;
+    }
+
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $events->attach(
+            MvcEvent::EVENT_RENDER,
+            function (MvcEvent $event) : void {
+                // this closure is just because of the lack of consistent callable usage in PHP
+                $this->onError($event);
+            }
+        );
+    }
+
+    /**
+     * Note: this code comes straight from
+     * @link https://akrabat.com/returning-json-errors-in-a-zf2-application/
+     *
+     * It wasn't tested via unit testing: that needs to happen before using it.
+     *
+     * This is just an example. Test.Your.Shit.
+     *
+     * Alternatively, you can use
+     * @link https://apigility.org/documentation/modules/zf-api-problem
+     *
+     * @param MvcEvent $error
+     */
+    private function onError(MvcEvent $error) : void
+    {
+        if (!$error->isError()) {
+            return;
+        }
+
+        $currentModel = $error->getResult();
+
+        if ($currentModel instanceof JsonModel) {
+            return;
+        }
+
+        if (! $this->acceptHeaderMatches($error)) {
+            return;
+        }
+
+        // use application/api-problem+json fields.
+        $response = $error->getResponse();
+
+        if (! $response instanceof Response) {
+            return;
+        }
+
+        $model = new JsonModel(array(
+            'httpStatus' => $response->getStatusCode(),
+            'title'      => $response->getReasonPhrase(),
+            'detail'     => $this->getExceptionMessage($error) ?? $this->getDetailReason($error),
+        ));
+
+        if ($messages = $this->getExceptionMessages($error)) {
+            $model->setVariable('messages', $messages);
+        }
+
+        $model->setTerminal(true);
+        $error->setResult($model);
+        $error->setViewModel($model);
+    }
+
+    private function getExceptionMessage(MvcEvent $event) : ?string
+    {
+        $exception = $this->getException($event);
+
+        if (! $exception) {
+            return null;
+        }
+
+        return $exception->getMessage();
+    }
+
+    private function getExceptionMessages(MvcEvent $event) : ?array
+    {
+        $exception = $this->getException($event);
+
+        if (! $exception) {
+            return null;
+        }
+
+        $messages = [];
+
+        do {
+            // @TODO this can be improved to include stack traces, files, etc
+            $messages[] = $exception->getMessage() . "\n\n" . $exception->__toString();
+        } while ($exception = $exception->getPrevious());
+
+        return $messages;
+    }
+
+    private function getException(MvcEvent $event) : ?\Throwable
+    {
+        if (! $this->displayExceptions) {
+            return null;
+        }
+
+        $currentModel = $event->getResult();
+
+        if (! $currentModel instanceof ModelInterface) {
+            return null;
+        }
+
+        $exception = $currentModel->getVariable('exception');
+
+        if (! $exception instanceof \Throwable) {
+            return null;
+        }
+
+        return $exception;
+    }
+
+    private function getDetailReason(MvcEvent $event) : string
+    {
+        $currentModel = $event->getResult();
+
+        if (! $currentModel instanceof ModelInterface || ! $currentModel->getVariable('reason')) {
+            return 'No reason provided';
+        }
+
+        $reasons = [
+            Application::ERROR_CONTROLLER_CANNOT_DISPATCH => 'The requested controller was unable to dispatch the request.',
+            Application::ERROR_CONTROLLER_NOT_FOUND => 'The requested controller could not be mapped to an existing controller class.',
+            Application::ERROR_CONTROLLER_INVALID => 'The requested controller was not dispatchable.',
+            Application::ERROR_ROUTER_NO_MATCH =>  'The requested URL could not be matched by routing.',
+        ];
+
+        return $reasons[$currentModel->getVariable('reason', '')]
+            ?? $currentModel->getVariable('message')
+            ?? 'No reason provided';
+    }
+
+    private function acceptHeaderMatches(MvcEvent $event) : bool
+    {
+        $request = $event->getRequest();
+
+        if (! $request instanceof Request) {
+            return false;
+        }
+
+        $headers = $request->getHeaders();
+
+        if (!$headers->has('Accept')) {
+            return false;
+        }
+
+        $accept = $headers->get('Accept');
+
+        if (! $accept instanceof Accept) {
+            return false;
+        }
+
+        $match  = $accept->match('application/json');
+
+        // note: we don't want wildcard matching, as that usually means "give me HTML"
+        return $match && '*/*' !== $match->getTypeString();
+    }
+}

--- a/module/JsonErrorHandling/src/JsonErrorHandling/JsonErrorHandlerFactory.php
+++ b/module/JsonErrorHandling/src/JsonErrorHandling/JsonErrorHandlerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JsonErrorHandling;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+final class JsonErrorHandlerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) : JsonErrorHandler
+    {
+        return new JsonErrorHandler($container->get('Config')['view_manager']['display_exceptions']);
+    }
+}

--- a/module/JsonErrorHandling/src/JsonErrorHandling/Module.php
+++ b/module/JsonErrorHandling/src/JsonErrorHandling/Module.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JsonErrorHandling;
+
+use Zend\EventManager\EventInterface;
+use Zend\ModuleManager\Feature\BootstrapListenerInterface;
+use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Zend\Mvc\Application;
+use Zend\View\Strategy\JsonStrategy;
+use Zend\View\View;
+
+class Module implements BootstrapListenerInterface, ConfigProviderInterface
+{
+    public function onBootstrap(EventInterface $e) : void
+    {
+        /* @var $app Application */
+        $app      = $e->getTarget();
+        $locator  = $app->getServiceManager();
+        $view     = $locator->get(View::class);
+        /* @var $strategy JsonStrategy */
+        $strategy = $locator->get('ViewJsonStrategy');
+
+        $strategy->attach($view->getEventManager(), 100);
+
+        $locator->get(JsonErrorHandler::class)->attach($app->getEventManager());
+    }
+
+    public function getConfig() : array
+    {
+        return [
+            'service_manager' => [
+                'factories' => [
+                    JsonErrorHandler::class => JsonErrorHandlerFactory::class,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Taken from @akrabat's excellent tutorial at https://akrabat.com/returning-json-errors-in-a-zf2-application/

This listener will intercept error rendering, and replace it with a JSON message if the request `Accept` header matches.